### PR TITLE
Remove cursor blink configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,25 +37,6 @@ hpm install nord-hyper
 ## Features
 <p align="center"><strong>Smooth transitions for tab interactions.</strong><br><img src="https://raw.githubusercontent.com/arcticicestudio/nord-hyper/develop/assets/scrot-feature-tabs.png"/><br><img src="https://raw.githubusercontent.com/arcticicestudio/nord-hyper/develop/assets/scrcast-feature-smooth-tab-transition.gif"/></p>
 
-
-## Configuration
-All configurations are set in the `nordHyper` object in your `~/.hyper.js` file.
-
-### Cursor Blinking
-The cursor blinking can be set with the `cursorBlink` attribute.  
-The default value is `true` to enable the non-obtrusive cursor blinking feature.
-```js
-module.exports = {
-  config: {
-    //...
-      nordHyper: {
-        cursorBlink: true,
-      }
-    //...
-  }
-}
-```
-
 ## Development
 [![](https://img.shields.io/badge/Changelog-0.4.0-81A1C1.svg?style=flat-square)](https://github.com/arcticicestudio/nord-hyper/blob/v0.4.0/CHANGELOG.md) [![](https://img.shields.io/badge/Workflow-gitflow--branching--model-81A1C1.svg?style=flat-square)](http://nvie.com/posts/a-successful-git-branching-model) [![](https://img.shields.io/badge/Versioning-ArcVer_0.8.0-81A1C1.svg?style=flat-square)](https://github.com/arcticicestudio/arcver)
 

--- a/index.js
+++ b/index.js
@@ -53,22 +53,7 @@ const colors = {
   grayscale: foregroundColor
 };
 
-let cursorBlinkCSS = `
-@keyframes blink {
-  10%, 50% { opacity: 0 }
-  60%, 100% { opacity: 1 }
-}
-.cursor-node[focus=true] {
-  mix-blend-mode: difference;
-}
-.cursor-node[focus=true]:not([hyper-blink-moving]) {
-  box-sizing: content-box !important;
-  animation: blink 1s ease infinite;
-}
-`;
-
 exports.decorateConfig = config => {
-  const nordHyper = Object.assign({cursorBlink: true}, config.nordHyper);
 
   return Object.assign({}, config, {
     foregroundColor,
@@ -87,7 +72,6 @@ exports.decorateConfig = config => {
       .cursor-node {
         border-left-width: 2px;
       }
-      ${nordHyper.cursorBlink ? cursorBlinkCSS : ""}
     `,
     css: `
       ${config.css || ""}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "bugs": {
     "url": "https://github.com/arcticicestudio/nord-hyper/issues"
   },
-  "license" : "(Apache-2.0 AND CC-BY-SA-4.0)",
+  "license": "(Apache-2.0 AND CC-BY-SA-4.0)",
   "main": "index.js",
   "keywords": [
     "arctic",


### PR DESCRIPTION
> Fixes #10

This PR removes the `cursorBlink` theme configuration, implemented in #7,  which caused the display to break when Hyper gets fully reloaded.

Users can switch to the builtin feature provided by Hyper introduced in version [1.3.0](https://github.com/zeit/hyper/releases/tag/1.3.0).

![gh-12-scrot-before](https://user-images.githubusercontent.com/7836623/31133016-954868ce-a85e-11e7-8b04-a6427a335be8.png)