### PR TITLE
update css selectors for hyper

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,10 +66,10 @@ exports.decorateConfig = config => {
     fontFamily: config.fontFamily || "'Source Code Pro', Hack",
     termCSS: `
       ${config.termCSS || ""}
-      ::selection {
+      .terminal .xterm-selection div {
         background: rgba(67, 76, 94, 0.8) !important;
       }
-      .cursor-node {
+      .terminal-cursor {
         border-left-width: 2px;
       }
     `,
@@ -84,7 +84,7 @@ exports.decorateConfig = config => {
         right: 0 !important;
         left: 0 !important;
       }
-      ::selection {
+      .terminal .xterm-selection div {
         background: rgba(67, 76, 94, 0.8) !important;
       }
       .tab_first {


### PR DESCRIPTION
> Closes #29

## Description

This pull request updates the deprecated CSS classes reported after upgrading Hyper to 2.0.0 (stable).

## References

Replacements were made based on the CSS mapping found within the Hyper repository [config.js](https://github.com/zeit/hyper/blob/f64e3e0204381f2667c6baa4cc78c6c844fc0f21/app/config.js#L140)
